### PR TITLE
Hotfix random ID length and health check config

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -7,17 +7,17 @@ resource "random_id" "lb_suffix" {
     tg_vpc_id          = "${var.vpc_id}"
   }
 
-  byte_length = 8
+  byte_length = 4
 }
 
 locals {
-  lb_name           = "${var.lb_name == "" ? format("%s-%s-%s", var.service_name, var.lb_internal ? "lbint" : "lbext", random_id.lb_suffix.b64_url) : var.lb_name}"
+  lb_name           = "${var.lb_name == "" ? format("%s-%s-%s", var.service_name, var.lb_internal ? "lbint" : "lbext", random_id.lb_suffix.hex) : var.lb_name}"
   tg_name           = "${var.tg_name == "" ? format("%s-%s", local.lb_name, "default") : var.tg_name}"
   target_group_arns = "${concat(list(aws_lb_target_group.default.arn), var.target_group_arns)}"
 }
 
 locals {
-  tg_health_check = {
+  tg_default_health_check = {
     "interval"            = 30
     "path"                = "/healthcheck"
     "port"                = 5000
@@ -27,4 +27,6 @@ locals {
     "protocol"            = "HTTP"
     "matcher"             = "200"
   }
+
+  tg_health_check = "${merge(tg_default_health_check, var.tg_health_check)}"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -28,5 +28,5 @@ locals {
     "matcher"             = "200"
   }
 
-  tg_health_check = "${merge(tg_default_health_check, var.tg_health_check)}"
+  tg_health_check = "${merge(local.tg_default_health_check, var.tg_health_check)}"
 }


### PR DESCRIPTION
Random ID byte_length of 8 is too long (target group max length is 32 < 14+16+length("default")), so it's reduced to 4 to make 10 characters available for target group suffix

tg_health_check variable was intended to be merged with the default, in locals. However it was not being used instead