### PR TITLE
hotfix/add-keepers

### DIFF
--- a/examples/frontend-backend-and-default-tgs/main.tf
+++ b/examples/frontend-backend-and-default-tgs/main.tf
@@ -35,14 +35,14 @@ locals {
 }
 
 module "random_fe" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.4.0"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.6.0"
 
   name_prefix   = "${format("%s-%s", local.service_name, "fe")}"
   resource_type = "lb_target_group"
 }
 
 module "random_be" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.4.0"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.6.0"
 
   name_prefix   = "${format("%s-%s", local.service_name, "app")}"
   resource_type = "lb_target_group"

--- a/locals.tf
+++ b/locals.tf
@@ -1,12 +1,20 @@
 module "random_lb" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.4.0"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.6.0"
 
   name_prefix   = "${format("%s-%s", var.service_name, var.lb_internal ? "lbint" : "lbext")}"
   resource_type = "lb"
+
+  keepers = {
+    lb_internal        = "${var.lb_internal}"
+    lb_ip_address_type = "${var.lb_ip_address_type}"
+    tg_port            = "${var.tg_port}"
+    tg_protocol        = "${var.tg_protocol}"
+    tg_vpc_id          = "${var.vpc_id}"
+  }
 }
 
 module "random_tg" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.4.0"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.6.0"
 
   name_prefix   = "${format("%s-%s", var.service_name, var.cluster_role)}"
   resource_type = "lb_target_group"


### PR DESCRIPTION
**FIX:**
* re-add keepers for lb name

**BACKGROUND:**
* on #1 original author (@salvianreynaldi) add these variable as `keepers` for lb name `random_id` resource:
  * lb_internal
  * lb_ip_address_type
  * tg_port
  * tg_protocol
  * tg_vpc_id
* on #5 @rafikurnia made a change from using `random_id` resource to using [traveloka/terraform-aws-resource-naming](https://github.com/traveloka/terraform-aws-resource-naming) module. At this time, that module does not support `keepers`
* `keepers` supported in traveloka/terraform-aws-resource-naming#8
* Since `keepers` is now supported, I don't want the functionality that original author has created to change, this PR exists for that.

Thanks