### PR TITLE
Add option to set target group type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,7 @@ resource "aws_lb_target_group" "default" {
   protocol             = "${var.tg_protocol}"
   vpc_id               = "${var.vpc_id}"
   deregistration_delay = "${var.tg_deregistration_delay}"
+  target_type          = "${var.tg_target_type}"
 
   health_check = ["${local.tg_health_check}"]
 

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "tg_health_check" {
   description = "The default target group's health check configuration, will be merged over the default (see locals.tf)"
 }
 
+variable "tg_target_type" {
+  type        = "string"
+  default     = "instance"
+  description = "The type of target that you must specify when registering targets with this target group."
+}
+
 variable "tg_stickiness" {
   type = "map"
 


### PR DESCRIPTION
Valid Values: instance | ip | lambda

https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html