### PR TITLE
Add listener ID and ARN to ouput

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,13 @@ output "tg_arn_suffix" {
   value       = "${aws_lb_target_group.default.arn_suffix}"
   description = "The arn suffix of the default target group, useful with CloudWatch Metrics"
 }
+
+output "listener_arn" {
+  value       = "The ARN of the listener"
+  description = "${aws_lb_listener.main.arn}"
+}
+
+output "listener_id" {
+  value       = "The ID of the listener"
+  description = "${aws_lb_listener.main.id}"
+}


### PR DESCRIPTION
`aws_lb_listener_certificate` needs ARN of listener to add custom certificate