### PR TITLE
upgrade to terraform v0.12 native syntax

### DIFF
--- a/examples/frontend-backend-and-default-tgs/main.tf
+++ b/examples/frontend-backend-and-default-tgs/main.tf
@@ -78,7 +78,7 @@ resource "aws_lb_target_group" "frontend" {
     ProductDomain = "${local.product_domain}"
     Environment   = "production"
     Description   = "Target group for ${local.service_name}-fe cluster"
-    ManagedBy     = "Terraform"
+    ManagedBy     = "terraform"
   }
 }
 
@@ -112,7 +112,7 @@ resource "aws_lb_target_group" "backend-canary" {
     ProductDomain = "${local.product_domain}"
     Environment   = "production"
     Description   = "Target group for ${local.service_name}-app cluster"
-    ManagedBy     = "Terraform"
+    ManagedBy     = "terraform"
   }
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,29 +1,33 @@
 module "random_lb" {
   source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.18.1"
 
-  name_prefix   = "${format("%s-%s", var.service_name, var.lb_internal ? "lbint" : "lbext")}"
+  name_prefix = format(
+    "%s-%s",
+    var.service_name,
+    var.lb_internal ? "lbint" : "lbext",
+  )
   resource_type = "lb"
 
   keepers = {
-    lb_internal        = "${var.lb_internal}"
-    lb_ip_address_type = "${var.lb_ip_address_type}"
-    tg_port            = "${var.tg_port}"
-    tg_protocol        = "${var.tg_protocol}"
-    tg_vpc_id          = "${var.vpc_id}"
+    lb_internal        = var.lb_internal
+    lb_ip_address_type = var.lb_ip_address_type
+    tg_port            = var.tg_port
+    tg_protocol        = var.tg_protocol
+    tg_vpc_id          = var.vpc_id
   }
 }
 
 module "random_tg" {
   source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.18.1"
 
-  name_prefix   = "${format("%s-%s", var.service_name, var.cluster_role)}"
+  name_prefix   = format("%s-%s", var.service_name, var.cluster_role)
   resource_type = "lb_target_group"
 }
 
 locals {
-  lb_name           = "${var.lb_name == "" ? module.random_lb.name : var.lb_name}"
-  tg_name           = "${var.tg_name == "" ? module.random_tg.name : var.tg_name}"
-  target_group_arns = "${concat(list(aws_lb_target_group.default.arn), var.target_group_arns)}"
+  lb_name           = var.lb_name == "" ? module.random_lb.name : var.lb_name
+  tg_name           = var.tg_name == "" ? module.random_tg.name : var.tg_name
+  target_group_arns = concat([aws_lb_target_group.default.arn], var.target_group_arns)
 }
 
 locals {
@@ -37,5 +41,5 @@ locals {
     "matcher"             = "200"
   }
 
-  tg_health_check = "${merge(local.tg_default_health_check, var.tg_health_check)}"
+  tg_health_check = merge(local.tg_default_health_check, var.tg_health_check)
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 module "random_lb" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.6.0"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.18.1"
 
   name_prefix   = "${format("%s-%s", var.service_name, var.lb_internal ? "lbint" : "lbext")}"
   resource_type = "lb"
@@ -14,7 +14,7 @@ module "random_lb" {
 }
 
 module "random_tg" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.6.0"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.18.1"
 
   name_prefix   = "${format("%s-%s", var.service_name, var.cluster_role)}"
   resource_type = "lb_target_group"

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "aws_lb" "main" {
       "Environment"   = var.environment
       "ProductDomain" = var.product_domain
       "Description"   = var.description
-      "ManagedBy"     = "Terraform"
+      "ManagedBy"     = "terraform"
     },
     var.lb_tags,
   )
@@ -90,7 +90,7 @@ resource "aws_lb_target_group" "default" {
       "Environment"   = var.environment
       "ProductDomain" = var.product_domain
       "Description"   = var.description
-      "ManagedBy"     = "Terraform"
+      "ManagedBy"     = "terraform"
     },
     var.tg_tags,
   )
@@ -110,27 +110,12 @@ resource "aws_lb_listener_rule" "main" {
   dynamic "condition" {
     for_each = [var.listener_conditions[count.index]]
     content {
-      # dynamic "host_header" {
-      #   for_each = [lookup(condition.value, "host_header", null)]
-      #   content {
-      #     values = lookup(host_header.value, "host_header", null)
-      #   }
-      # }
-
-      # dynamic "http_header" {
-      #   for_each = [lookup(condition.value, "http_header", null)]
-      #   content {
-      #     http_header_name = http_header.value.http_header_name
-      #     values           = http_header.value.values
-      #   }
-      # }
-
-      # dynamic "http_request_method" {
-      #   for_each = [lookup(condition.value, "http_request_method", null)]
-      #   content {
-      #     values = http_request_method.value.values
-      #   }
-      # }
+      dynamic "host_header" {
+        for_each = [lookup(condition.value, "host_header", null)]
+        content {
+          values = host_header.value
+        }
+      }
 
       dynamic "path_pattern" {
         for_each = [lookup(condition.value, "path_pattern", null)]
@@ -138,21 +123,6 @@ resource "aws_lb_listener_rule" "main" {
           values = path_pattern.value
         }
       }
-
-      # dynamic "query_string" {
-      #   for_each = [lookup(condition.value, "query_string", null)]
-      #   content {
-      #     key   = lookup(query_string.value, "key", null)
-      #     value = query_string.value.value
-      #   }
-      # }
-
-      # dynamic "source_ip" {
-      #   for_each = [lookup(condition.value, "source_ip", null)]
-      #   content {
-      #     values = source_ip.value.values
-      #   }
-      # }
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -114,14 +114,14 @@ resource "aws_lb_listener_rule" "main" {
       values = lookup(condition.value, "values", null)
 
       dynamic "host_header" {
-        for_each = lookup(condition.value, "host_header", [])
+        for_each = [lookup(condition.value, "host_header", null)]
         content {
           values = lookup(host_header.value, "values", null)
         }
       }
 
       dynamic "http_header" {
-        for_each = lookup(condition.value, "http_header", [])
+        for_each = [lookup(condition.value, "http_header", null)]
         content {
           http_header_name = http_header.value.http_header_name
           values           = http_header.value.values
@@ -129,21 +129,21 @@ resource "aws_lb_listener_rule" "main" {
       }
 
       dynamic "http_request_method" {
-        for_each = lookup(condition.value, "http_request_method", [])
+        for_each = [lookup(condition.value, "http_request_method", null)]
         content {
           values = http_request_method.value.values
         }
       }
 
       dynamic "path_pattern" {
-        for_each = lookup(condition.value, "path_pattern", [])
+        for_each = [lookup(condition.value, "path_pattern", null)]
         content {
           values = lookup(path_pattern.value, "values", null)
         }
       }
 
       dynamic "query_string" {
-        for_each = lookup(condition.value, "query_string", [])
+        for_each = [lookup(condition.value, "query_string", null)]
         content {
           key   = lookup(query_string.value, "key", null)
           value = query_string.value.value
@@ -151,7 +151,7 @@ resource "aws_lb_listener_rule" "main" {
       }
 
       dynamic "source_ip" {
-        for_each = lookup(condition.value, "source_ip", [])
+        for_each = [lookup(condition.value, "source_ip", null)]
         content {
           values = source_ip.value.values
         }

--- a/main.tf
+++ b/main.tf
@@ -108,54 +108,51 @@ resource "aws_lb_listener_rule" "main" {
   }
 
   dynamic "condition" {
-    for_each = var.listener_conditions[count.index]
+    for_each = [var.listener_conditions[count.index]]
     content {
-      field  = lookup(condition.value, "field", null)
-      values = lookup(condition.value, "values", null)
+      # dynamic "host_header" {
+      #   for_each = [lookup(condition.value, "host_header", null)]
+      #   content {
+      #     values = lookup(host_header.value, "host_header", null)
+      #   }
+      # }
 
-      dynamic "host_header" {
-        for_each = [lookup(condition.value, "host_header", null)]
-        content {
-          values = lookup(host_header.value, "values", null)
-        }
-      }
+      # dynamic "http_header" {
+      #   for_each = [lookup(condition.value, "http_header", null)]
+      #   content {
+      #     http_header_name = http_header.value.http_header_name
+      #     values           = http_header.value.values
+      #   }
+      # }
 
-      dynamic "http_header" {
-        for_each = [lookup(condition.value, "http_header", null)]
-        content {
-          http_header_name = http_header.value.http_header_name
-          values           = http_header.value.values
-        }
-      }
-
-      dynamic "http_request_method" {
-        for_each = [lookup(condition.value, "http_request_method", null)]
-        content {
-          values = http_request_method.value.values
-        }
-      }
+      # dynamic "http_request_method" {
+      #   for_each = [lookup(condition.value, "http_request_method", null)]
+      #   content {
+      #     values = http_request_method.value.values
+      #   }
+      # }
 
       dynamic "path_pattern" {
         for_each = [lookup(condition.value, "path_pattern", null)]
         content {
-          values = lookup(path_pattern.value, "values", null)
+          values = path_pattern.value
         }
       }
 
-      dynamic "query_string" {
-        for_each = [lookup(condition.value, "query_string", null)]
-        content {
-          key   = lookup(query_string.value, "key", null)
-          value = query_string.value.value
-        }
-      }
+      # dynamic "query_string" {
+      #   for_each = [lookup(condition.value, "query_string", null)]
+      #   content {
+      #     key   = lookup(query_string.value, "key", null)
+      #     value = query_string.value.value
+      #   }
+      # }
 
-      dynamic "source_ip" {
-        for_each = [lookup(condition.value, "source_ip", null)]
-        content {
-          values = source_ip.value.values
-        }
-      }
+      # dynamic "source_ip" {
+      #   for_each = [lookup(condition.value, "source_ip", null)]
+      #   content {
+      #     values = source_ip.value.values
+      #   }
+      # }
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "aws_lb_listener_rule" "main" {
   }
 
   dynamic "condition" {
-    for_each = [var.listener_conditions[count.index]]
+    for_each = var.listener_conditions[count.index]
     content {
       field  = lookup(condition.value, "field", null)
       values = lookup(condition.value, "values", null)

--- a/main.tf
+++ b/main.tf
@@ -10,76 +10,152 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 resource "aws_lb" "main" {
-  name     = "${local.lb_name}"
-  internal = "${var.lb_internal}"
+  name     = local.lb_name
+  internal = var.lb_internal
 
-  security_groups = ["${var.lb_security_groups}"]
+  security_groups = var.lb_security_groups
 
-  subnets         = ["${var.lb_subnet_ids}"]
-  idle_timeout    = "${var.lb_idle_timeout}"
-  ip_address_type = "${var.lb_ip_address_type}"
+  subnets         = var.lb_subnet_ids
+  idle_timeout    = var.lb_idle_timeout
+  ip_address_type = var.lb_ip_address_type
 
   access_logs {
-    bucket  = "${var.lb_logs_s3_bucket_name}"
-    prefix  = "${local.lb_name}"
+    bucket  = var.lb_logs_s3_bucket_name
+    prefix  = local.lb_name
     enabled = true
   }
 
-  tags = "${merge(map(
-    "Name", local.lb_name,
-    "Service", var.service_name,
-    "Environment", var.environment,
-    "ProductDomain", var.product_domain,
-    "Description", var.description,
-    "ManagedBy", "Terraform",
-    ), var.lb_tags)}"
+  tags = merge(
+    {
+      "Name"          = local.lb_name
+      "Service"       = var.service_name
+      "Environment"   = var.environment
+      "ProductDomain" = var.product_domain
+      "Description"   = var.description
+      "ManagedBy"     = "Terraform"
+    },
+    var.lb_tags,
+  )
 }
 
 resource "aws_lb_listener" "main" {
-  load_balancer_arn = "${aws_lb.main.arn}"
+  load_balancer_arn = aws_lb.main.arn
   port              = 443
   protocol          = "HTTPS"
-  ssl_policy        = "${var.listener_ssl_policy}"
-  certificate_arn   = "${var.listener_certificate_arn}"
+  ssl_policy        = var.listener_ssl_policy
+  certificate_arn   = var.listener_certificate_arn
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.default.arn}"
+    target_group_arn = aws_lb_target_group.default.arn
     type             = "forward"
   }
 }
 
 resource "aws_lb_target_group" "default" {
-  name                 = "${local.tg_name}"
-  port                 = "${var.tg_port}"
-  protocol             = "${var.tg_protocol}"
-  vpc_id               = "${var.vpc_id}"
-  deregistration_delay = "${var.tg_deregistration_delay}"
-  target_type          = "${var.tg_target_type}"
+  name                 = local.tg_name
+  port                 = var.tg_port
+  protocol             = var.tg_protocol
+  vpc_id               = var.vpc_id
+  deregistration_delay = var.tg_deregistration_delay
+  target_type          = var.tg_target_type
 
-  health_check = ["${local.tg_health_check}"]
+  dynamic "health_check" {
+    for_each = [local.tg_health_check]
+    content {
+      enabled             = lookup(health_check.value, "enabled", null)
+      healthy_threshold   = lookup(health_check.value, "healthy_threshold", null)
+      interval            = lookup(health_check.value, "interval", null)
+      matcher             = lookup(health_check.value, "matcher", null)
+      path                = lookup(health_check.value, "path", null)
+      port                = lookup(health_check.value, "port", null)
+      protocol            = lookup(health_check.value, "protocol", null)
+      timeout             = lookup(health_check.value, "timeout", null)
+      unhealthy_threshold = lookup(health_check.value, "unhealthy_threshold", null)
+    }
+  }
 
-  stickiness = ["${var.tg_stickiness}"]
+  dynamic "stickiness" {
+    for_each = [var.tg_stickiness]
+    content {
+      cookie_duration = lookup(stickiness.value, "cookie_duration", null)
+      enabled         = lookup(stickiness.value, "enabled", null)
+      type            = stickiness.value.type
+    }
+  }
 
-  tags = "${merge(map(
-    "Name", local.tg_name,
-    "Service", var.service_name,
-    "Environment", var.environment,
-    "ProductDomain", var.product_domain,
-    "Description", var.description,
-    "ManagedBy", "Terraform",
-    ), var.tg_tags)}"
+  tags = merge(
+    {
+      "Name"          = local.tg_name
+      "Service"       = var.service_name
+      "Environment"   = var.environment
+      "ProductDomain" = var.product_domain
+      "Description"   = var.description
+      "ManagedBy"     = "Terraform"
+    },
+    var.tg_tags,
+  )
 }
 
 resource "aws_lb_listener_rule" "main" {
-  count        = "${length(var.listener_conditions)}"
-  listener_arn = "${aws_lb_listener.main.arn}"
+  count        = length(var.listener_conditions)
+  listener_arn = aws_lb_listener.main.arn
 
-  priority = "${count.index + 1}"
+  priority = count.index + 1
 
   action {
     type             = "forward"
-    target_group_arn = "${local.target_group_arns[var.listener_target_group_idx[count.index]]}"
+    target_group_arn = local.target_group_arns[var.listener_target_group_idx[count.index]]
   }
 
-  condition = ["${var.listener_conditions[count.index]}"]
+  dynamic "condition" {
+    for_each = [var.listener_conditions[count.index]]
+    content {
+      field  = lookup(condition.value, "field", null)
+      values = lookup(condition.value, "values", null)
+
+      dynamic "host_header" {
+        for_each = lookup(condition.value, "host_header", [])
+        content {
+          values = lookup(host_header.value, "values", null)
+        }
+      }
+
+      dynamic "http_header" {
+        for_each = lookup(condition.value, "http_header", [])
+        content {
+          http_header_name = http_header.value.http_header_name
+          values           = http_header.value.values
+        }
+      }
+
+      dynamic "http_request_method" {
+        for_each = lookup(condition.value, "http_request_method", [])
+        content {
+          values = http_request_method.value.values
+        }
+      }
+
+      dynamic "path_pattern" {
+        for_each = lookup(condition.value, "path_pattern", [])
+        content {
+          values = lookup(path_pattern.value, "values", null)
+        }
+      }
+
+      dynamic "query_string" {
+        for_each = lookup(condition.value, "query_string", [])
+        content {
+          key   = lookup(query_string.value, "key", null)
+          value = query_string.value.value
+        }
+      }
+
+      dynamic "source_ip" {
+        for_each = lookup(condition.value, "source_ip", [])
+        content {
+          values = source_ip.value.values
+        }
+      }
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -111,16 +111,16 @@ resource "aws_lb_listener_rule" "main" {
     for_each = [var.listener_conditions[count.index]]
     content {
       dynamic "host_header" {
-        for_each = [lookup(condition.value, "host_header", null)]
+        for_each = lookup(condition.value, "host_header", null) != null ? [" using host header "] : []
         content {
-          values = host_header.value
+          values = lookup(condition.value, "host_header")
         }
       }
 
       dynamic "path_pattern" {
-        for_each = [lookup(condition.value, "path_pattern", null)]
+        for_each = lookup(condition.value, "path_pattern", null) != null ? [" using path pattern "] : []
         content {
-          values = path_pattern.value
+          values = lookup(condition.value, "path_pattern")
         }
       }
     }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,44 +1,45 @@
 output "lb_dns" {
-  value       = "${aws_lb.main.dns_name}"
+  value       = aws_lb.main.dns_name
   description = "The DNS name of the load balancer"
 }
 
 output "lb_zone_id" {
-  value       = "${aws_lb.main.zone_id}"
+  value       = aws_lb.main.zone_id
   description = "The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record)"
 }
 
 output "lb_arn" {
-  value       = "${aws_lb.main.arn}"
+  value       = aws_lb.main.arn
   description = "The ARN of the ALB"
 }
 
 output "lb_arn_suffix" {
-  value       = "${aws_lb.main.arn_suffix}"
+  value       = aws_lb.main.arn_suffix
   description = "The ARN suffix of the ALB, useful with CloudWatch Metrics"
 }
 
 output "tg_arn" {
-  value       = "${aws_lb_target_group.default.arn}"
+  value       = aws_lb_target_group.default.arn
   description = "The arn of the default target group"
 }
 
 output "tg_arn_suffix" {
-  value       = "${aws_lb_target_group.default.arn_suffix}"
+  value       = aws_lb_target_group.default.arn_suffix
   description = "The arn suffix of the default target group, useful with CloudWatch Metrics"
 }
 
 output "tg_name" {
-  value       = "${aws_lb_target_group.default.name}"
+  value       = aws_lb_target_group.default.name
   description = "The name of the target group"
 }
 
 output "listener_arn" {
-  value       = "${aws_lb_listener.main.arn}"
+  value       = aws_lb_listener.main.arn
   description = "The ARN of the listener"
 }
 
 output "listener_id" {
-  value       = "${aws_lb_listener.main.id}"
+  value       = aws_lb_listener.main.id
   description = "The ID of the listener"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -109,7 +109,7 @@ variable "listener_ssl_policy" {
 }
 
 variable "listener_conditions" {
-  type        = list(string)
+  type        = list(map(string))
   default     = []
   description = "List of conditions (https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html#condition) for the listener rules. A rule can have either 1 or 2 conditions. The rule's order will be its priority, i.e. the first is the highest"
 }
@@ -155,4 +155,3 @@ variable "cluster_role" {
   type        = string
   description = "Primary role/function of the cluster. Example value: 'app', 'fe', 'mongod', etc"
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -1,62 +1,62 @@
 variable "lb_name" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The name of the LB, will override the default <service_name>-<lb_type>-<random_string> name"
 }
 
 variable "lb_logs_s3_bucket_name" {
-  type        = "string"
+  type        = string
   description = "The S3 bucket that will be used to store LB access logs"
 }
 
 variable "lb_internal" {
-  type        = "string"
+  type        = string
   default     = true
   description = "Whether the LB will be public / private"
 }
 
 variable "lb_security_groups" {
-  type        = "list"
+  type        = list(string)
   description = "List of security group IDs for the LB"
 }
 
 variable "lb_subnet_ids" {
-  type        = "list"
+  type        = list(string)
   description = "List of subnet IDs of the LB"
 }
 
 variable "lb_ip_address_type" {
-  type        = "string"
+  type        = string
   default     = "ipv4"
   description = "The LB's ip address type"
 }
 
 variable "lb_idle_timeout" {
-  type        = "string"
+  type        = string
   default     = 60
   description = "The LB's idle timeout"
 }
 
 variable "lb_tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "The additional LB tags that will be merged over the default tags"
 }
 
 variable "tg_health_check" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "The default target group's health check configuration, will be merged over the default (see locals.tf)"
 }
 
 variable "tg_target_type" {
-  type        = "string"
+  type        = string
   default     = "instance"
   description = "The type of target that you must specify when registering targets with this target group."
 }
 
 variable "tg_stickiness" {
-  type = "map"
+  type = map(string)
 
   default = {
     "type"            = "lb_cookie"
@@ -68,90 +68,91 @@ variable "tg_stickiness" {
 }
 
 variable "tg_name" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The default target group's name, will override the default <service_name>-default name"
 }
 
 variable "tg_port" {
-  type        = "string"
+  type        = string
   default     = 5000
   description = "The default target group's port"
 }
 
 variable "tg_protocol" {
-  type        = "string"
+  type        = string
   default     = "HTTP"
   description = "The default target group's protocol"
 }
 
 variable "tg_deregistration_delay" {
-  type        = "string"
+  type        = string
   default     = 300
   description = "The default target group's deregistration delay"
 }
 
 variable "tg_tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "The additional Target Group tags that will be merged over the default tags"
 }
 
 variable "listener_certificate_arn" {
-  type        = "string"
+  type        = string
   description = "The LB listener's certificate ARN"
 }
 
 variable "listener_ssl_policy" {
-  type        = "string"
+  type        = string
   default     = "ELBSecurityPolicy-2016-08"
   description = "The LB listener's SSL policy"
 }
 
 variable "listener_conditions" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of conditions (https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html#condition) for the listener rules. A rule can have either 1 or 2 conditions. The rule's order will be its priority, i.e. the first is the highest"
 }
 
 variable "listener_target_group_idx" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Indexes, starting from 0, of the `target_group_arns` variable that the listener rules will use when choosing target groups. '0' means the default target group"
 }
 
 variable "service_name" {
-  type        = "string"
+  type        = string
   description = "The service name that will be used in tags and resources default name"
 }
 
 variable "description" {
-  type        = "string"
+  type        = string
   description = "Will be used in resources' Description tag"
 }
 
 variable "environment" {
-  type        = "string"
+  type        = string
   description = "Will be used in resources' Environment tag"
 }
 
 variable "product_domain" {
-  type        = "string"
+  type        = string
   description = "Abbreviation of the product domain the created resources belong to"
 }
 
 variable "target_group_arns" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "A list of target group arns, will be used by listener rules using `listener_target_group_idx` variable"
 }
 
 variable "vpc_id" {
-  type        = "string"
+  type        = string
   description = "The default target group's VPC"
 }
 
 variable "cluster_role" {
-  type        = "string"
+  type        = string
   description = "Primary role/function of the cluster. Example value: 'app', 'fe', 'mongod', etc"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -109,7 +109,7 @@ variable "listener_ssl_policy" {
 }
 
 variable "listener_conditions" {
-  type        = list(object({path_pattern = list(string)}))
+  type        = list(map(list(string)))
   default     = []
   description = "List of conditions (https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html#condition) for the listener rules. A rule can have either 1 or 2 conditions. The rule's order will be its priority, i.e. the first is the highest"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "lb_logs_s3_bucket_name" {
 
 variable "lb_internal" {
   type        = string
-  default     = true
+  default     = "1"
   description = "Whether the LB will be public / private"
 }
 
@@ -109,7 +109,7 @@ variable "listener_ssl_policy" {
 }
 
 variable "listener_conditions" {
-  type        = list(object({field=string, values = list(string)}))
+  type        = list(object({path_pattern = list(string)}))
   default     = []
   description = "List of conditions (https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html#condition) for the listener rules. A rule can have either 1 or 2 conditions. The rule's order will be its priority, i.e. the first is the highest"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -109,7 +109,7 @@ variable "listener_ssl_policy" {
 }
 
 variable "listener_conditions" {
-  type        = list(map(string))
+  type        = list(object({field=string, values = list(string)}))
   default     = []
   description = "List of conditions (https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html#condition) for the listener rules. A rule can have either 1 or 2 conditions. The rule's order will be its priority, i.e. the first is the highest"
 }


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-alb-single-listener/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

- Require terraform v0.12.0+

FEATURES:

ENHANCEMENTS:

- use new resource naming module which is compatible with terraform v0.12

BUG FIXES:

```

***
Successfully applied to a [private stack](https://github.com/traveloka/bei-miscellaneous/commit/b51ef9649468bb491e6eef54ced14be49c60cb95), from terraform 0.11.14 to 0.12.24, without any resource re-creations. Here's the output of `terraform apply`:
```

  # module.asg.aws_autoscaling_group.main will be updated in-place
  ~ resource "aws_autoscaling_group" "main" {
        arn                       = <redacted>
        availability_zones        = [
            <redacted>
        ]
        default_cooldown          = 300
        desired_capacity          = 1
        enabled_metrics           = [
            "GroupDesiredCapacity",
            "GroupInServiceInstances",
            "GroupMaxSize",
            "GroupMinSize",
            "GroupPendingInstances",
            "GroupStandbyInstances",
            "GroupTerminatingInstances",
            "GroupTotalInstances",
        ]
        force_delete              = false
        health_check_grace_period = 300
        health_check_type         = "EC2"
        id                        = <redacted>
        load_balancers            = []
        max_instance_lifetime     = 0
        max_size                  = 1
        metrics_granularity       = "1Minute"
        min_size                  = 1
        name                      = <redacted>
        name_prefix               = <redacted>
        protect_from_scale_in     = false
        service_linked_role_arn   = <redacted>
        suspended_processes       = []
      ~ tags                      = [
          - {
              - "key"                 = "Name"
              - "propagate_at_launch" = "0"
              - "value"               = <redacted>
            },
          - {
              - "key"                 = "Service"
              - "propagate_at_launch" = "0"
              - "value"               = <redacted>
            },
          - {
              - "key"                 = "ProductDomain"
              - "propagate_at_launch" = "0"
              - "value"               = "bei"
            },
          - {
              - "key"                 = "Environment"
              - "propagate_at_launch" = "0"
              - "value"               = "staging"
            },
          - {
              - "key"                 = "Description"
              - "propagate_at_launch" = "0"
              - "value"               = "ASG of the <redacted> cluster"
            },
          - {
              - "key"                 = "ManagedBy"
              - "propagate_at_launch" = "0"
              - "value"               = "terraform"
            },
          - {
              - "key"                 = "nonprodmonitoring"
              - "propagate_at_launch" = "1"
              - "value"               = "false"
            },
          + {
              + "key"                 = "Name"
              + "propagate_at_launch" = "false"
              + "value"               = <redacted>
            },
          + {
              + "key"                 = "Service"
              + "propagate_at_launch" = "false"
              + "value"               = <redacted>
            },
          + {
              + "key"                 = "ProductDomain"
              + "propagate_at_launch" = "false"
              + "value"               = "bei"
            },
          + {
              + "key"                 = "Environment"
              + "propagate_at_launch" = "false"
              + "value"               = "staging"
            },
          + {
              + "key"                 = "Description"
              + "propagate_at_launch" = "false"
              + "value"               = "ASG of the <redacted> cluster"
            },
          + {
              + "key"                 = "ManagedBy"
              + "propagate_at_launch" = "false"
              + "value"               = "terraform"
            },
          + {
              + "key"                 = "nonprodmonitoring"
              + "propagate_at_launch" = "true"
              + "value"               = "false"
            },
          + {
              + "key"                 = "spot-enabled"
              + "propagate_at_launch" = "true"
              + "value"               = "true"
            },
        ]
        target_group_arns         = [
            <redacted>
        ]
        termination_policies      = [
            "Default",
        ]
        vpc_zone_identifier       = [
            <redacted>,
        ]
        wait_for_capacity_timeout = "1m"
        wait_for_elb_capacity     = 1

        mixed_instances_policy {
            instances_distribution {
                on_demand_allocation_strategy            = "prioritized"
                on_demand_base_capacity                  = 0
                on_demand_percentage_above_base_capacity = 100
                spot_allocation_strategy                 = "lowest-price"
                spot_instance_pools                      = 2
            }

            launch_template {
                launch_template_specification {
                    launch_template_id   = <redacted>
                    launch_template_name = <redacted>
                    version              = "$Latest"
                }

                override {
                    instance_type = "t3.medium"
                }
            }
        }

        timeouts {}
    }

  # module.asg.aws_launch_template.main will be updated in-place
  ~ resource "aws_launch_template" "main" {
        arn                     = <redacted>
        default_version         = 1
        disable_api_termination = false
        ebs_optimized           = "false"
        id                      = <redacted>
        image_id                = <redacted>
        key_name                = <redacted>
      ~ latest_version          = 1 -> (known after apply)
        name                    = <redacted>
        security_group_names    = []
        tags                    = {
            "Environment"   = "staging"
            "ManagedBy"     = "terraform"
            "Name"          = <redacted>
            "ProductDomain" = "bei"
            "Service"       = <redacted>
        }
        user_data               = <redacted>
        vpc_security_group_ids  = []

      ~ block_device_mappings {
            device_name = "/dev/sda1"

          ~ ebs {
                delete_on_termination = "true"
              + encrypted             = "false"
                iops                  = 0
                volume_size           = 8
                volume_type           = "gp2"
            }
        }

        credit_specification {
            cpu_credits = "unlimited"
        }

        iam_instance_profile {
            name = "profile-generic-app"
        }

        monitoring {
            enabled = true
        }

      + network_interfaces {
          + associate_public_ip_address = "false"
        }

        tag_specifications {
            resource_type = "instance"
            tags          = {
                "Application"   = "java-8"
                "Cluster"       = <redacted>
                "Description"   = "Autoscaling Group for <redacted>"
                "Environment"   = "staging"
                "ManagedBy"     = "terraform"
                "Name"          = <redacted>
                "ProductDomain" = "bei"
                "Service"       = <redacted>
            }
        }
        tag_specifications {
            resource_type = "volume"
            tags          = {
                "Environment"   = "staging"
                "ManagedBy"     = "terraform"
                "ProductDomain" = "bei"
                "Service"       = <redacted>
            }
        }
    }

Plan: 0 to add, 2 to change, 0 to destroy.


Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/alb.random_lb/main.tf line 27, in resource "random_id" "this":
  27:   prefix      = "${local.prefix}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.

(and 11 more similar warnings elsewhere)


Warning: Quoted type constraints are deprecated

  on .terraform/modules/alb.random_lb/variables.tf line 3, in variable "name_prefix":
   3:   type        = "string"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "string".

(and 11 more similar warnings elsewhere)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: 

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
