### PR TITLE
Allow passing in listener_port and listener_protocol as arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ A terraform module which provisions a DNS record that points to an Application L
 | tg_protocol | The default target group's protocol. | `string` | `HTTP` | no |
 | tg_deregistration_delay | The default target group's deregistration delay. | `string` | `300` | no |
 | tg_tags | The additional Target Group tags that will be merged over the default tags. | `map` | `{}` | no |
+| listener_port | The LB listener's port. | `string` | `443` | yes |
+| listener_protocol | The LB listener's protocol. | `string` | `HTTPS` | yes |
 | listener_certificate_arn | The LB listener's certificate ARN. | `string` | n/a | yes if `tg_protocol` is set to HTTPS |
 | listener_ssl_policy | The LB listener's SSL policy. | `string` | `ELBSecurityPolicy-2016-08` | no |
 | listener_conditions | List of conditions (https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html#condition) for the listener rules. A rule can have either 1 or 2 conditions. The rule's order will be its priority, i.e. the first is the highest. | `list` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -40,8 +40,8 @@ resource "aws_lb" "main" {
 
 resource "aws_lb_listener" "main" {
   load_balancer_arn = aws_lb.main.arn
-  port              = 443
-  protocol          = "HTTPS"
+  port              = var.listener_port
+  protocol          = var.listener_protocol
   ssl_policy        = var.listener_ssl_policy
   certificate_arn   = var.listener_certificate_arn
 

--- a/variables.tf
+++ b/variables.tf
@@ -97,6 +97,17 @@ variable "tg_tags" {
   description = "The additional Target Group tags that will be merged over the default tags"
 }
 
+variable "listener_port" {
+  type        = string
+  default     = 443
+  description = "The LB listener's port"
+}
+
+variable "listener_protocol" {
+  type        = string
+  default     = "HTTPS"
+  description = "The LB listener's protocol"
+}
 variable "listener_certificate_arn" {
   type        = string
   description = "The LB listener's certificate ARN"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Allow a user to setup an ALB without HTTPS.  Use case is for internal backend services. Example:

```
listener_port = 7233
listener_protocol = "HTTP"
listener_ssl_policy = null
listener_certificate_arn = null
```

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-alb-single-listener/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Allow a user to setup an ALB without HTTPS.

FEATURES:

* Allow a user to setup an ALB without HTTPS.

ENHANCEMENTS:

* feature: Allow a user to setup an ALB without HTTPS.

```

***

Output from `terraform plan` command from changes you propose.

```
~ resource "aws_lb_listener" "main" {
      ~ port              = 443 -> 7233
      ~ protocol          = "HTTPS" -> "HTTP"
   }
```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
