### PR TITLE
Support tg_protocol_version as arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A terraform module which provisions a DNS record that points to an Application L
 | tg_name | The default target group's name, will override the default <service_name>-default name. | `string` | n/a | no |
 | tg_port | The default target group's port. | `string` | `5000` | no |
 | tg_protocol | The default target group's protocol. | `string` | `HTTP` | no |
+| tg_protocol_version | The default target group's protocol version. | `string` | `HTTP1` | no |
 | tg_deregistration_delay | The default target group's deregistration delay. | `string` | `300` | no |
 | tg_tags | The additional Target Group tags that will be merged over the default tags. | `map` | `{}` | no |
 | listener_port | The LB listener's port. | `string` | `443` | yes |

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ resource "aws_lb_target_group" "default" {
   name                 = local.tg_name
   port                 = var.tg_port
   protocol             = var.tg_protocol
+  protocol_version     = var.tg_protocol_version
   vpc_id               = var.vpc_id
   deregistration_delay = var.tg_deregistration_delay
   target_type          = var.tg_target_type

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,12 @@ variable "tg_protocol" {
   description = "The default target group's protocol"
 }
 
+variable "tg_protocol_version" {
+  type        = string
+  default     = "HTTP1"
+  description = "The default target group's protocol version"
+}
+
 variable "tg_deregistration_delay" {
   type        = string
   default     = 300


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***
Allow a user to setup an ALB with [gRPC support](https://aws.amazon.com/blogs/aws/new-application-load-balancer-support-for-end-to-end-http-2-and-grpc/). Use case is for internal backend services. Example usage:

```
...
tg_protocol    = "HTTP"
tg_protocol_version = "GRPC"
tg_health_check = {
    path = "/AWS.ALB/healthcheck"
    matcher = "12"
}
...

```

<!---
State an issue that you address on this PR.
--->

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-alb-single-listener/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note

FEATURES:

* Allow a user to setup an ALB with [gRPC support](https://aws.amazon.com/blogs/aws/new-application-load-balancer-support-for-end-to-end-http-2-and-grpc/).

```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```
...
      + protocol                           = "HTTP"
      + protocol_version                   = "GRPC"
      + proxy_protocol_v2                  = false
...
```
```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
