### PR TITLE
Ignore changes on listener rule's target_group_arn if it targets the built-in target group

### DIFF
--- a/examples/frontend-backend-and-default-tgs/main.tf
+++ b/examples/frontend-backend-and-default-tgs/main.tf
@@ -8,7 +8,7 @@ locals {
   service_name   = "${local.product_domain}ops"
   vpc_id         = "vpc-14b12345"
 
-  frontend_condition = [
+  frontend_conditions = [
     {
       "field"  = "host-header"
       "values" = ["m.traveloka.com"]
@@ -19,14 +19,14 @@ locals {
     },
   ]
 
-  backend_canary_condition = [
+  backend_canary_conditions = [
     {
       "field"  = "path-pattern"
       "values" = ["/canary/"]
     },
   ]
 
-  backend_default_condition = [
+  backend_default_conditions = [
     {
       "field"  = "host-header"
       "values" = ["fpr.traveloka.com"]
@@ -128,13 +128,11 @@ module "alb-single-listener" {
   lb_security_groups       = ["sg-07eb717e"]
   lb_subnet_ids            = ["subnet-b1123456", "subnet-a0d12345", "subnet-e7607d12"]
 
-  listener_conditions = "${list(local.frontend_condition, local.backend_canary_condition, local.backend_default_condition)}"
+  listener_rules = {
+    0 = {target=aws_lb_target_group.frontend.arn, conditions=local.frontend_conditions},
+    10 = {target=null, conditions=local.backend_default_conditions},
+    99 = {target=aws_lb_target_group.backend-canary.arn, conditions=local.backend_canary_conditions},
+  }
 
-  target_group_arns = [
-    "${aws_lb_target_group.frontend.arn}",
-    "${aws_lb_target_group.backend-canary.arn}",
-  ]
-
-  listener_target_group_idx = [1, 2, 0]
   vpc_id                    = "${local.vpc_id}"
 }

--- a/examples/frontend-backend-and-default-tgs/main.tf
+++ b/examples/frontend-backend-and-default-tgs/main.tf
@@ -129,9 +129,9 @@ module "alb-single-listener" {
   lb_subnet_ids            = ["subnet-b1123456", "subnet-a0d12345", "subnet-e7607d12"]
 
   listener_rules = {
-    0 = {target=aws_lb_target_group.frontend.arn, conditions=local.frontend_conditions},
-    10 = {target=null, conditions=local.backend_default_conditions},
-    99 = {target=aws_lb_target_group.backend-canary.arn, conditions=local.backend_canary_conditions},
+    0 = {target_group_arn=aws_lb_target_group.frontend.arn, conditions=local.frontend_conditions},
+    10 = {target_group_arn=null, conditions=local.backend_default_conditions},
+    99 = {target_group_arn=aws_lb_target_group.backend-canary.arn, conditions=local.backend_canary_conditions},
   }
 
   vpc_id                    = "${local.vpc_id}"

--- a/locals.tf
+++ b/locals.tf
@@ -38,6 +38,8 @@ locals {
 }
 
 locals {
+  listener_rules_builtin = { for k,v in var.listener_rules : k => v if lookup(v, "target_group_arn", null) == null }
+  listener_rules_custom = { for k,v in var.listener_rules : k => v if lookup(v, "target_group_arn", null) != null }
   tg_default_health_check = {
     "interval"            = 30
     "path"                = "/healthcheck"

--- a/locals.tf
+++ b/locals.tf
@@ -38,8 +38,12 @@ locals {
 }
 
 locals {
+  # as of terraform 0.12.31, it's not possible to have dynamic "ignore_changes"
+  # https://github.com/hashicorp/terraform/issues/24188
+  # so we need to separate rules that target the built-in target group (which changes should be ignored), from those that don't.
   listener_rules_builtin = { for k,v in var.listener_rules : k => v if lookup(v, "target_group_arn", null) == null }
   listener_rules_custom = { for k,v in var.listener_rules : k => v if lookup(v, "target_group_arn", null) != null }
+
   tg_default_health_check = {
     "interval"            = 30
     "path"                = "/healthcheck"

--- a/locals.tf
+++ b/locals.tf
@@ -35,7 +35,6 @@ locals {
   lb_name           = var.lb_name == "" ? module.random_lb.name : var.lb_name
   tg_name           = var.tg_name == "" ? module.random_tg.name : var.tg_name
   tg_name_standby   = module.random_tg_standby.name
-  target_group_arns = concat([aws_lb_target_group.init_active.arn], var.target_group_arns)
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -93,18 +93,18 @@ resource "aws_lb_target_group" "init_active" {
 }
 
 resource "aws_lb_listener_rule" "main" {
-  count        = length(var.listener_conditions)
+  for_each = var.listener_rules
   listener_arn = aws_lb_listener.main.arn
 
-  priority = count.index + 1
+  priority = each.key
 
   action {
     type             = "forward"
-    target_group_arn = local.target_group_arns[var.listener_target_group_idx[count.index]]
+    target_group_arn = lookup(each.value, "htarget_group_arn", null) != null ? each.value["target_group_arn"] : aws_lb_target_group.init_active.arn
   }
 
   dynamic "condition" {
-    for_each = [var.listener_conditions[count.index]]
+    for_each = each.value["conditions"]
     content {
       dynamic "host_header" {
         for_each = lookup(condition.value, "host_header", null) != null ? [" using host header "] : []
@@ -121,7 +121,41 @@ resource "aws_lb_listener_rule" "main" {
       }
     }
   }
+  dynamic "lifecycle" {
+    for_each = []
+  }
 }
+
+# resource "aws_lb_listener_rule" "main" {
+#   count        = length(var.listener_conditions)
+#   listener_arn = aws_lb_listener.main.arn
+
+#   priority = count.index + 1
+
+#   action {
+#     type             = "forward"
+#     target_group_arn = local.target_group_arns[var.listener_target_group_idx[count.index]]
+#   }
+
+#   dynamic "condition" {
+#     for_each = [var.listener_conditions[count.index]]
+#     content {
+#       dynamic "host_header" {
+#         for_each = lookup(condition.value, "host_header", null) != null ? [" using host header "] : []
+#         content {
+#           values = lookup(condition.value, "host_header")
+#         }
+#       }
+
+#       dynamic "path_pattern" {
+#         for_each = lookup(condition.value, "path_pattern", null) != null ? [" using path pattern "] : []
+#         content {
+#           values = lookup(condition.value, "path_pattern")
+#         }
+#       }
+#     }
+#   }
+# }
 
 
 resource "aws_lb_target_group" "init_standby" {

--- a/main.tf
+++ b/main.tf
@@ -107,16 +107,15 @@ resource "aws_lb_listener_rule" "custom" {
     for_each = each.value["conditions"]
     content {
       dynamic "host_header" {
-        for_each = lookup(condition.value, "host_header", null) != null ? [" using host header "] : []
+        for_each = lookup(condition.value, "field", null) == "host-header" ? [" using host header "] : []
         content {
-          values = lookup(condition.value, "host_header")
+          values = lookup(condition.value, "values", null)
         }
       }
-
       dynamic "path_pattern" {
-        for_each = lookup(condition.value, "path_pattern", null) != null ? [" using path pattern "] : []
+        for_each = lookup(condition.value, "field", null) == "path-pattern" ? [" using path pattern "] : []
         content {
-          values = lookup(condition.value, "path_pattern")
+          values = lookup(condition.value, "values", null)
         }
       }
     }
@@ -135,19 +134,27 @@ resource "aws_lb_listener_rule" "builtin" {
   }
 
   dynamic "condition" {
+    # each.value here contains a list of conditions, e.g.
+    # [{
+    #     "field"  = "host-header"
+    #     "values" = ["m.traveloka.com"]
+    #   },
+    #   {
+    #     "field"  = "path-pattern"
+    #     "values" = ["/frontend/"]
+    # }]
     for_each = each.value
     content {
       dynamic "host_header" {
-        for_each = lookup(condition.value, "host_header", null) != null ? [" using host header "] : []
+        for_each = lookup(condition.value, "field", null) == "host-header" ? [" using host header "] : []
         content {
-          values = lookup(condition.value, "host_header")
+          values = lookup(condition.value, "values", null)
         }
       }
-
       dynamic "path_pattern" {
-        for_each = lookup(condition.value, "path_pattern", null) != null ? [" using path pattern "] : []
+        for_each = lookup(condition.value, "field", null) == "path-pattern" ? [" using path pattern "] : []
         content {
-          values = lookup(condition.value, "path_pattern")
+          values = lookup(condition.value, "values", null)
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "aws_lb_target_group" "init_active" {
 }
 
 resource "aws_lb_listener_rule" "custom" {
-  for_each = var.listener_rules_custom
+  for_each = local.listener_rules_custom
   listener_arn = aws_lb_listener.main.arn
 
   priority = each.key
@@ -123,7 +123,7 @@ resource "aws_lb_listener_rule" "custom" {
 }
 
 resource "aws_lb_listener_rule" "builtin" {
-  for_each = var.listener_rules_builtin
+  for_each = local.listener_rules_builtin
   listener_arn = aws_lb_listener.main.arn
 
   priority = each.key
@@ -134,7 +134,7 @@ resource "aws_lb_listener_rule" "builtin" {
   }
 
   dynamic "condition" {
-    # each.value here contains a list of conditions, e.g.
+    # each.value["conditions"] here contains a list of conditions, e.g.
     # [{
     #     "field"  = "host-header"
     #     "values" = ["m.traveloka.com"]
@@ -143,7 +143,7 @@ resource "aws_lb_listener_rule" "builtin" {
     #     "field"  = "path-pattern"
     #     "values" = ["/frontend/"]
     # }]
-    for_each = each.value
+    for_each = each.value["conditions"]
     content {
       dynamic "host_header" {
         for_each = lookup(condition.value, "field", null) == "host-header" ? [" using host header "] : []

--- a/main.tf
+++ b/main.tf
@@ -92,15 +92,15 @@ resource "aws_lb_target_group" "init_active" {
   )
 }
 
-resource "aws_lb_listener_rule" "main" {
-  for_each = var.listener_rules
+resource "aws_lb_listener_rule" "custom" {
+  for_each = var.listener_rules_custom
   listener_arn = aws_lb_listener.main.arn
 
   priority = each.key
 
   action {
     type             = "forward"
-    target_group_arn = lookup(each.value, "htarget_group_arn", null) != null ? each.value["target_group_arn"] : aws_lb_target_group.init_active.arn
+    target_group_arn = each.value["target_group_arn"]
   }
 
   dynamic "condition" {
@@ -121,42 +121,41 @@ resource "aws_lb_listener_rule" "main" {
       }
     }
   }
-  dynamic "lifecycle" {
-    for_each = []
-  }
 }
 
-# resource "aws_lb_listener_rule" "main" {
-#   count        = length(var.listener_conditions)
-#   listener_arn = aws_lb_listener.main.arn
+resource "aws_lb_listener_rule" "builtin" {
+  for_each = var.listener_rules_builtin
+  listener_arn = aws_lb_listener.main.arn
 
-#   priority = count.index + 1
+  priority = each.key
 
-#   action {
-#     type             = "forward"
-#     target_group_arn = local.target_group_arns[var.listener_target_group_idx[count.index]]
-#   }
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.init_active.arn
+  }
 
-#   dynamic "condition" {
-#     for_each = [var.listener_conditions[count.index]]
-#     content {
-#       dynamic "host_header" {
-#         for_each = lookup(condition.value, "host_header", null) != null ? [" using host header "] : []
-#         content {
-#           values = lookup(condition.value, "host_header")
-#         }
-#       }
+  dynamic "condition" {
+    for_each = each.value
+    content {
+      dynamic "host_header" {
+        for_each = lookup(condition.value, "host_header", null) != null ? [" using host header "] : []
+        content {
+          values = lookup(condition.value, "host_header")
+        }
+      }
 
-#       dynamic "path_pattern" {
-#         for_each = lookup(condition.value, "path_pattern", null) != null ? [" using path pattern "] : []
-#         content {
-#           values = lookup(condition.value, "path_pattern")
-#         }
-#       }
-#     }
-#   }
-# }
-
+      dynamic "path_pattern" {
+        for_each = lookup(condition.value, "path_pattern", null) != null ? [" using path pattern "] : []
+        content {
+          values = lookup(condition.value, "path_pattern")
+        }
+      }
+    }
+  }
+  lifecycle {
+    ignore_changes = [action[0].target_group_arn]
+  }
+}
 
 resource "aws_lb_target_group" "init_standby" {
   name                 = local.tg_name_standby

--- a/variables.tf
+++ b/variables.tf
@@ -113,6 +113,12 @@ variable "listener_ssl_policy" {
   description = "The LB listener's SSL policy"
 }
 
+variable "listener_rules" {
+  type        = map
+  default     = {}
+  description = "A map of map, for listener rules: priority --> {target_group_arn:'', conditions:[]}"
+}
+
 variable "listener_conditions" {
   type        = list(map(list(string)))
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -113,22 +113,16 @@ variable "listener_ssl_policy" {
   description = "The LB listener's SSL policy"
 }
 
-variable "listener_rules" {
+variable "listener_rules_builtin" {
   type        = map
   default     = {}
-  description = "A map of map, for listener rules: priority --> {target_group_arn:'', conditions:[]}"
+  description = "A map of listener rules which target the built-in target group: priority --> conditions:[]"
 }
 
-variable "listener_conditions" {
-  type        = list(map(list(string)))
-  default     = []
-  description = "List of conditions (https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html#condition) for the listener rules. A rule can have either 1 or 2 conditions. The rule's order will be its priority, i.e. the first is the highest"
-}
-
-variable "listener_target_group_idx" {
-  type        = list(string)
-  default     = []
-  description = "Indexes, starting from 0, of the `target_group_arns` variable that the listener rules will use when choosing target groups. '0' means the default target group"
+variable "listener_rules_custom" {
+  type        = map
+  default     = {}
+  description = "A map of listener rules which target the supplied target groups: priority --> {target_group_arn:'', conditions:[]}"
 }
 
 variable "service_name" {
@@ -151,15 +145,9 @@ variable "product_domain" {
   description = "Abbreviation of the product domain the created resources belong to"
 }
 
-variable "target_group_arns" {
-  type        = list(string)
-  default     = []
-  description = "A list of target group arns, will be used by listener rules using `listener_target_group_idx` variable"
-}
-
 variable "vpc_id" {
   type        = string
-  description = "The default target group's VPC"
+  description = "The built-in target group's VPC"
 }
 
 variable "cluster_role" {

--- a/variables.tf
+++ b/variables.tf
@@ -113,16 +113,11 @@ variable "listener_ssl_policy" {
   description = "The LB listener's SSL policy"
 }
 
-variable "listener_rules_builtin" {
-  type        = map
-  default     = {}
-  description = "A map of listener rules which target the built-in target group: priority --> conditions:[]"
-}
 
-variable "listener_rules_custom" {
+variable "listener_rules" {
   type        = map
   default     = {}
-  description = "A map of listener rules which target the supplied target groups: priority --> {target_group_arn:'', conditions:[]}"
+  description = "A map of listener rules: priority --> {target_group_arn:'', conditions:[]}. 'target_group_arn:null' means the builtin target group"
 }
 
 variable "service_name" {


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***
# Summary
<!---
State an issue that you address on this PR.
--->
When deploying to ECS with AWS CodeDeploy (CD, needs 2 target group for each ECS service), CD will manage the active and the standby target group in a ALB listener rule. Therefore, we have `ignore_changes` the default listener rule's target group [here](https://github.com/traveloka/terraform-aws-alb-single-listener/blob/codedeploy/main.tf#L54). However, it's actually possible to have custom rules target the built-in target group, hence the changes to that rule's should be ignored, too. This PR enables that.

With the previous `listener_conditions`, `target_group_arns`, and `listener_target_group_idx`, it's pretty difficult to find such target groups. Moreover, the `count` meta-argument (terraform 0.11 limitation) that we used to provision multiple listener rules are less reliable than the new `for_each`. Therefore, I'm refactoring these variables as well. The changes required from the client-side can be seen in the updated example.

***
# Test
I've manually tested this change in our lab account.
- If one doesn't use listener rules, there will be no changes when they upgrade the alb module, as this PR only touches the ALB listener rules

# TODO
- [ ] update readme
