### PR TITLE
Add slow_start variable to LB Target Group

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.22.0
+  rev: v1.50.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A terraform module which provisions a DNS record that points to an Application L
 | lb_tags | The additional LB tags that will be merged over the default tags. | `map` | `{}` | no |
 | tg_health_check | The default target group's health check configuration, will be merged over the default (see locals.tf). | `map` | `{}` | no |
 | tg_target_type | The type of target that you must specify when registering targets with this target group. | `string` | `instance` | no |
+| tg_slow_start | Amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds. | `string` | `0` | no |
 | tg_stickiness | The default target group's stickiness configuration. | `map` | `default = { "type" = "lb_cookie" "cookie_duration" = 1 "enabled" = true }` | no |
 | tg_name | The default target group's name, will override the default <service_name>-default name. | `string` | n/a | no |
 | tg_port | The default target group's port. | `string` | `5000` | no |

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ resource "aws_lb_target_group" "default" {
   vpc_id               = "${var.vpc_id}"
   deregistration_delay = "${var.tg_deregistration_delay}"
   target_type          = "${var.tg_target_type}"
+  slow_start           = "${var.tg_slow_start}"
 
   health_check = ["${local.tg_health_check}"]
 

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "tg_target_type" {
   description = "The type of target that you must specify when registering targets with this target group."
 }
 
+variable "tg_slow_start" {
+  type        = "string"
+  default     = 0
+  description = "Amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds."
+}
+
 variable "tg_stickiness" {
   type = "map"
 


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-alb-single-listener/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note

FEATURES:

* Add capability to set slow_start for LB Target Group

BUG FIXES:

* Update pre-commit-terraform version to v1.50.0 to fix terraform-docs error below:
* Error: unknown flag: --with-aggregate-type-defaults 
```

***

Output from `terraform plan` command from changes you propose.

```
  ~ module.app.module.lbint.aws_lb_target_group.default
      slow_start: "0" => "60"

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
