### PR TITLE
Add attribute drop_invalid_header_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The latest stable version of Terraform which this module tested working is Terra
 | <a name="input_lb_idle_timeout"></a> [lb\_idle\_timeout](#input\_lb\_idle\_timeout) | The LB's idle timeout | `string` | `60` | no |
 | <a name="input_lb_internal"></a> [lb\_internal](#input\_lb\_internal) | Whether the LB will be public / private | `string` | `"1"` | no |
 | <a name="input_lb_ip_address_type"></a> [lb\_ip\_address\_type](#input\_lb\_ip\_address\_type) | The LB's ip address type | `string` | `"ipv4"` | no |
+| <a name="input_lb_drop_invalid_header_fields"></a> [lb\_drop\_invalid\_header\_fields](#input\_lb\_drop\_invalid\_header\_fields) | The LB's attribute to drop invalid header fields | `string` | `true` | no |
 | <a name="input_lb_logs_s3_bucket_name"></a> [lb\_logs\_s3\_bucket\_name](#input\_lb\_logs\_s3\_bucket\_name) | The S3 bucket that will be used to store LB access logs | `string` | n/a | yes |
 | <a name="input_lb_name"></a> [lb\_name](#input\_lb\_name) | The name of the LB, will override the default <service\_name>-<lb\_type>-<random\_string> name | `string` | `""` | no |
 | <a name="input_lb_security_groups"></a> [lb\_security\_groups](#input\_lb\_security\_groups) | List of security group IDs for the LB | `list(string)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -15,9 +15,10 @@ resource "aws_lb" "main" {
 
   security_groups = var.lb_security_groups
 
-  subnets         = var.lb_subnet_ids
-  idle_timeout    = var.lb_idle_timeout
-  ip_address_type = var.lb_ip_address_type
+  subnets                    = var.lb_subnet_ids
+  idle_timeout               = var.lb_idle_timeout
+  ip_address_type            = var.lb_ip_address_type
+  drop_invalid_header_fields = var.lb_drop_invalid_header_fields
 
   access_logs {
     bucket  = var.lb_logs_s3_bucket_name

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "lb_ip_address_type" {
   description = "The LB's ip address type"
 }
 
+variable "lb_drop_invalid_header_fields" {
+  type        = string
+  default     = true
+  description = "The LB's attribute to drop invalid header fields"
+}
+
 variable "lb_idle_timeout" {
   type        = string
   default     = 60


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #0000
Based on some static code test guide, it is a good practice to set drop_invalid_header_fields  attribute to true.
References:
https://docs.bridgecrew.io/docs/ensure-that-alb-drops-http-headers
https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/ELBv2/drop-invalid-header-fields-enabled.html
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#:~:text=is%20defensive.-,routing,-.http.drop_invalid_header_fields.enabled

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-alb-single-listener/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Any Notes regarding your submitted PR, like breaking changes or else.

FEATURES:

* **New Source:** `aws_000_0000` ([#references_to_issue](./))

ENHANCEMENTS:

* feature: Add support for new version of AWS API

BUG FIXES:

* Prevent error from evil bugs
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
