### PR TITLE
Modify ssl_policy to ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
-- repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.50.0
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.79.1
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
-- repo: git://github.com/pre-commit/pre-commit-hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.0.1
   hooks:
     - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The latest stable version of Terraform which this module tested working is Terra
 | <a name="input_listener_port"></a> [listener\_port](#input\_listener\_port) | The LB listener's port | `string` | `443` | no |
 | <a name="input_listener_protocol"></a> [listener\_protocol](#input\_listener\_protocol) | The LB listener's protocol | `string` | `"HTTPS"` | no |
 | <a name="input_listener_rules"></a> [listener\_rules](#input\_listener\_rules) | A map of listener rules for the LB: priority --> {target\_group\_arn:'', conditions:[]}. 'target\_group\_arn:null' means the built-in target group | `map(any)` | `{}` | no |
-| <a name="input_listener_ssl_policy"></a> [listener\_ssl\_policy](#input\_listener\_ssl\_policy) | The LB listener's SSL policy | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| <a name="input_listener_ssl_policy"></a> [listener\_ssl\_policy](#input\_listener\_ssl\_policy) | The LB listener's SSL policy | `string` | `"ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06"` | no |
 | <a name="input_product_domain"></a> [product\_domain](#input\_product\_domain) | Abbreviation of the product domain the created resources belong to | `string` | n/a | yes |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | The service name that will be used in tags and resources default name | `string` | n/a | yes |
 | <a name="input_tg_deregistration_delay"></a> [tg\_deregistration\_delay](#input\_tg\_deregistration\_delay) | The default target group's deregistration delay | `string` | `300` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -127,7 +127,7 @@ variable "listener_certificate_arn" {
 
 variable "listener_ssl_policy" {
   type        = string
-  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  default     = "ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06"
   description = "The LB listener's SSL policy"
 }
 


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Allow additional cipher methods.

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-alb-single-listener/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Change ssl_policy to ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
